### PR TITLE
chore: update config file to build techdoc local instead of docker

### DIFF
--- a/setup/backstage/app-config.yaml
+++ b/setup/backstage/app-config.yaml
@@ -29,7 +29,7 @@ proxy: {}
 techdocs:
   builder: 'local'
   generator:
-    runIn: 'docker'
+    runIn: 'local'
   publisher:
     type: 'local'
 


### PR DESCRIPTION
# Pull Request: Update TechDocs Configuration

## Changes Made
- Modified the TechDocs generator configuration in `setup/backstage/app-config.yaml`
- Changed the `runIn` parameter from 'docker' to 'local' for the TechDocs generator

## Description
This PR updates the TechDocs configuration to use local generation instead of Docker. This change simplifies the TechDocs generation process by running it directly on the host machine rather than in a Docker container.

## Technical Details
- File modified: `setup/backstage/app-config.yaml`
- Configuration change: TechDocs generator `runIn` parameter
- Previous value: `'docker'`
- New value: `'local'`

## Impact
- Reduces containerization overhead for TechDocs generation
- Simplifies the development and documentation workflow
- May improve generation speed by eliminating container startup time

## Testing
Please verify that:
- [ ] TechDocs generation works correctly in the local environment
- [ ] Documentation builds successfully
- [ ] No regression in documentation quality or formatting

## Related Issues
[Add any related issue numbers here]

## Additional Notes
This change is part of our ongoing efforts to streamline the documentation process and improve development workflow efficiency.